### PR TITLE
Fixed request of access token

### DIFF
--- a/src/API/Api.php
+++ b/src/API/Api.php
@@ -148,7 +148,7 @@ class Api
     {
         $params['grant_type'] = $grantType;
 
-        $response = $this->client->request('GET', $this->config['endpoints']['oauth'] . $method, [
+        $response = $this->client->send('POST', $this->config['endpoints']['oauth'] . $method, [
             'headers' => [
                 'Authorization' => 'Basic ' . base64_encode($this->config['api']['key'] . ':' . $this->config['api']['secret']),
             ],
@@ -186,7 +186,9 @@ class Api
 
         // If auth is required, append access token
         if ($auth) {
-            $body['headers'] = 'Bearer ' . $this->getAccessToken();
+            $body['headers'] = [
+                'Authorization' => 'Bearer ' . $this->getAccessToken(),
+            ];
         }
 
         if (!empty($query))


### PR DESCRIPTION
Requesting an access token from Trustpilot's API was not working in the current version. According to https://documentation-apidocumentation.trustpilot.com/authentication, a POST request must be used rather than a GET request, as is used in the current version. In addition, the Bearer token was not being properly added to the headers array for the request. This version fixes both these bugs.