### PR TITLE
Correct type hints for optional parameters in category methods and constructors

### DIFF
--- a/src/API/BusinessUnit/BusinessUnit.php
+++ b/src/API/BusinessUnit/BusinessUnit.php
@@ -11,7 +11,7 @@ class BusinessUnit extends Resource
 {
 
     /**
-     * Initialise the business unit with an optional business unit id.
+     * Initialize the business unit with an optional business unit id.
      * If no business unit id is given, it uses the business unit from the config.
      *
      * @param null|string $businessUnitId
@@ -64,11 +64,11 @@ class BusinessUnit extends Resource
     /**
      * Get the business categories.
      *
-     * @param string $country
-     * @param string $locale
+     * @param null|string $country
+     * @param null|string $locale
      * @return mixed
      */
-    public function categories(string $country = null, string $locale = null)
+    public function categories(?string $country = null, ?string $locale = null)
     {
         return (new BusinessUnitApi())->categories($this->id, $country, $locale);
     }

--- a/src/API/BusinessUnit/BusinessUnitApi.php
+++ b/src/API/BusinessUnit/BusinessUnitApi.php
@@ -37,11 +37,11 @@ class BusinessUnitApi extends ResourceApi
      * Get the business categories.
      *
      * @param string $businessUnitId
-     * @param string $country
-     * @param string $locale
+     * @param null|string $country
+     * @param null|string $locale
      * @return mixed
      */
-    public function categories(string $businessUnitId, string $country = null, string $locale = null)
+    public function categories(string $businessUnitId, ?string $country = null, ?string $locale = null)
     {
         $response = $this->get('/' . $businessUnitId . '/categories', array_filter([
             'country' => $country,

--- a/src/API/BusinessUnit/Product/ProductApi.php
+++ b/src/API/BusinessUnit/Product/ProductApi.php
@@ -26,7 +26,7 @@ class ProductApi extends ResourceApi
      *
      * @param string|null $businessUnitId
      */
-    public function __construct(string $businessUnitId = null)
+    public function __construct(?string $businessUnitId = null)
     {
         parent::__construct();
         $this->businessUnitId = $businessUnitId ?? config('trustpilot.unit_id');


### PR DESCRIPTION
This PR fixes parameters of the form `Type $param = null`, where the [null](https://www.php.net/manual/en/reserved.constants.php#constant.null) default makes the type implicitly nullable. 

This usage is deprecated as of PHP 8.4.0, and an explicit [nullable type](https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.nullable) should be used instead.

see: https://www.php.net/manual/en/functions.arguments.php